### PR TITLE
Refactor event delegation final

### DIFF
--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -34,18 +34,15 @@
       new EventBinder({listener: this.listener, tuple: tuple});
     },
     _delegateEvents: function() {
-      var events = this.events;
-      var delegateViewEvents = this.delegateViewEvents;
-      var self = this,
-          listener = this.listener;
-      _.chain(events).toArray().compact().each(function(obj) {
+      var self = this;
+      _.chain(this.events).toArray().compact().each(function(obj) {
         var arg = _(obj);
         if (arg.isArray()) {
           self.customBindEvents(obj);
         } else {
           arg.each(function(callbacks, event) {
             _.chain([callbacks]).flatten().each(function(callback) {
-              delegateViewEvents.call(listener, _.tap({}, function(obj) {
+              self.delegateViewEvents.call(self.listener, _.tap({}, function(obj) {
                 obj[event] = callback;
               }));
             });
@@ -65,12 +62,11 @@
   }
   _.extend(EventHandler.prototype, {
     parse: function() {
-      var listener = this.listener;
       var self = this;
       _.each(this.subject && this.eventNames, function(callback, event) {
         _.each(event.split(' '), function(e) {
           _.chain([callback]).flatten().each(function(c) {
-            var fn = _.isFunction(c) ? c : listener[c];
+            var fn = _.isFunction(c) ? c : self.listener[c];
             self.handle(e, fn);
           });
         });
@@ -121,7 +117,7 @@
         new EventUnbinder({listener: listener, tuple: tuple});
       });
       // TODO is this needed? deleting it leaves all specs passing
-      this.oldUndelegateEvents.call(this.listener);
+      this.oldUndelegateEvents.call(listener);
     }
   });
 
@@ -134,16 +130,16 @@
         }),
 
         delegateEvents: _.wrap(source.prototype.delegateEvents, function(oldDelegateEvents) {
-          var self = this, args = _.rest(arguments);
+          var args = _.rest(arguments);
           if (!args.length) {
             return oldDelegateEvents.call(this);
           }
           new EventDelegator({
             delegateViewEvents: oldDelegateEvents,
-            listener: self,
+            listener: this,
             events: args
           });
-
+          return this;
         }),
 
         undelegateEvents: _.wrap(source.prototype.undelegateEvents, function(oldUndelegateEvents) {

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -14,12 +14,12 @@
 
   _.extend(EventDelegator.prototype, {
     delegateEvents: function() {
-      this.undelegateEvents();
+      this.preventDuplicateDelegation();
       this.temporarilyDisableUndelegation();
       this._delegateEvents();
       this.restoreUndelegation();
     },
-    undelegateEvents: function() {
+    preventDuplicateDelegation: function() {
       this.listener.undelegateEvents();
     },
     temporarilyDisableUndelegation: function() {

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -114,7 +114,6 @@
       _.each(this.modelEvents, function(tuple) {
         new EventUnbinder({listener: listener, tuple: tuple});
       });
-      // TODO is this needed? deleting it leaves all specs passing
       this.oldUndelegateEvents.call(listener);
     }
   });

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -4,13 +4,13 @@
 
   function noop() {}
 
-  var EventDelegator = function(params) {
+  function EventDelegator(params) {
     this.listener = params.listener;
     this.events = params.events;
     this.delegateViewEvents = params.delegateViewEvents;
     this.oldUndelegateEvents = this.listener.undelegateEvents;
     this.delegateEvents();
-  };
+  }
 
   _.extend(EventDelegator.prototype, {
     delegateEvents: function() {
@@ -49,48 +49,68 @@
     }
   });
 
-  function bindModelEvents(tuple) {
-    var self = this, subject = tuple[0], eventNames = tuple[1], isJquery = !!_(subject).result('jquery'),
-        modelEvents = self._modelCallbacks, context = tuple[2];
-    modelEvents.push(tuple);
-    _.each(subject && eventNames, function(callback, event) {
-      _.each(event.split(' '), function(e) {
-        _.chain([callback]).flatten().each(function(c) {
-          var fn = _.isFunction(c) ? c : self[c];
-          if (isJquery) {
-            if (context) {
-              subject.on(e, context, fn);
-            } else {
-              subject.on(e, fn);
-            }
-          } else {
-            subject.on(e, fn, context);
-          }
+  function EventHandler(params) {
+    this.listener = params.listener;
+    var tuple = params.tuple;
+    this.subject = tuple[0];
+    this.eventNames = tuple[1];
+    this.context = tuple[2];
+    this.parse();
+  }
+  _.extend(EventHandler.prototype, {
+    parse: function() {
+      var listener = this.listener;
+      var self = this;
+      _.each(this.subject && this.eventNames, function(callback, event) {
+        _.each(event.split(' '), function(e) {
+          _.chain([callback]).flatten().each(function(c) {
+            var fn = _.isFunction(c) ? c : listener[c];
+            self.handle(e, fn);
+          });
         });
       });
-    });
+    },
+    isJquery: function() {
+      return !!_(this.subject).result('jquery');
+    },
+    handle: function(e, fn) {
+      var handler = this.methodName;
+      if (this.isJquery()) {
+        if (this.context) {
+          this.subject[handler](e, this.context, fn);
+        } else {
+          this.subject[handler](e, fn);
+        }
+      } else {
+        this.subject[handler](e, fn, this.context);
+      }
+    }
+  });
+
+  function EventBinder() {
+    EventHandler.apply(this, arguments);
+  }
+  _.extend(EventBinder.prototype, EventHandler.prototype, {
+    methodName: 'on'
+  });
+
+  function EventUnbinder() {
+    EventHandler.apply(this, arguments);
+  }
+  _.extend(EventUnbinder.prototype, EventHandler.prototype, {
+    methodName: 'off'
+  });
+
+  function bindModelEvents(tuple) {
+    var modelEvents = this._modelCallbacks;
+    modelEvents.push(tuple);
+    new EventBinder({listener: this, tuple: tuple});
   }
 
   function unbindModelEvents() {
     var self = this, modelEvents = self._modelCallbacks;
     _.each(modelEvents, function(tuple) {
-      var subject = tuple[0], events = tuple[1], context = tuple[2], isJquery = !!_.result(subject, 'jquery');
-      _.each(subject && events, function(callback, event) {
-        _.each(event.split(' '), function(e) {
-          _.chain([callback]).flatten().each(function(c) {
-            var fn = _.isFunction(c) ? c : self[c];
-            if (isJquery) {
-              if (context) {
-                subject.off(e, context, fn);
-              } else {
-                subject.off(e, fn);
-              }
-            } else {
-              subject.off(e, fn);
-            }
-          });
-        });
-      });
+      new EventUnbinder({listener: self, tuple: tuple});
     });
   }
 

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -4,54 +4,6 @@
 
   function noop() {}
 
-  function EventDelegator(params) {
-    this.listener = params.listener;
-    this.events = params.events;
-    this.delegateViewEvents = params.delegateViewEvents;
-    this.oldUndelegateEvents = this.listener.undelegateEvents;
-    this.delegateEvents();
-  }
-
-  _.extend(EventDelegator.prototype, {
-    delegateEvents: function() {
-      this.preventDuplicateDelegation();
-      this.temporarilyDisableUndelegation();
-      this._delegateEvents();
-      this.restoreUndelegation();
-    },
-    preventDuplicateDelegation: function() {
-      this.listener.undelegateEvents();
-    },
-    temporarilyDisableUndelegation: function() {
-      this.listener.undelegateEvents = noop;
-    },
-    restoreUndelegation: function() {
-      this.listener.undelegateEvents = this.oldUndelegateEvents;
-    },
-    customBindEvents: function(tuple) {
-      var customBindings = this.listener._customBindings;
-      customBindings.push(tuple);
-      new EventBinder({listener: this.listener, tuple: tuple});
-    },
-    _delegateEvents: function() {
-      var self = this;
-      _.chain(this.events).toArray().compact().each(function(obj) {
-        var arg = _(obj);
-        if (arg.isArray()) {
-          self.customBindEvents(obj);
-        } else {
-          arg.each(function(callbacks, event) {
-            _.chain([callbacks]).flatten().each(function(callback) {
-              self.delegateViewEvents.call(self.listener, _.tap({}, function(obj) {
-                obj[event] = callback;
-              }));
-            });
-          });
-        }
-      });
-    }
-  });
-
   function EventHandler(params) {
     this.listener = params.listener;
     var tuple = params.tuple;
@@ -99,6 +51,54 @@
   }
   _.extend(EventUnbinder.prototype, EventHandler.prototype, {
     methodName: 'off'
+  });
+
+  function EventDelegator(params) {
+    this.listener = params.listener;
+    this.events = params.events;
+    this.delegateViewEvents = params.delegateViewEvents;
+    this.oldUndelegateEvents = this.listener.undelegateEvents;
+    this.delegateEvents();
+  }
+
+  _.extend(EventDelegator.prototype, {
+    delegateEvents: function() {
+      this.preventDuplicateDelegation();
+      this.temporarilyDisableUndelegation();
+      this._delegateEvents();
+      this.restoreUndelegation();
+    },
+    preventDuplicateDelegation: function() {
+      this.listener.undelegateEvents();
+    },
+    temporarilyDisableUndelegation: function() {
+      this.listener.undelegateEvents = noop;
+    },
+    restoreUndelegation: function() {
+      this.listener.undelegateEvents = this.oldUndelegateEvents;
+    },
+    customBindEvents: function(tuple) {
+      var customBindings = this.listener._customBindings;
+      customBindings.push(tuple);
+      new EventBinder({listener: this.listener, tuple: tuple});
+    },
+    _delegateEvents: function() {
+      var self = this;
+      _.chain(this.events).toArray().compact().each(function(obj) {
+        var arg = _(obj);
+        if (arg.isArray()) {
+          self.customBindEvents(obj);
+        } else {
+          arg.each(function(callbacks, event) {
+            _.chain([callbacks]).flatten().each(function(callback) {
+              self.delegateViewEvents.call(self.listener, _.tap({}, function(obj) {
+                obj[event] = callback;
+              }));
+            });
+          });
+        }
+      });
+    }
   });
 
   function EventUndelegator(params) {

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -29,8 +29,8 @@
       this.listener.undelegateEvents = this.oldUndelegateEvents;
     },
     customBindEvents: function(tuple) {
-      var modelEvents = this.listener._modelCallbacks;
-      modelEvents.push(tuple);
+      var customBindings = this.listener._customBindings;
+      customBindings.push(tuple);
       new EventBinder({listener: this.listener, tuple: tuple});
     },
     _delegateEvents: function() {
@@ -104,14 +104,14 @@
   function EventUndelegator(params) {
     this.listener = params.listener;
     this.oldUndelegateEvents = params.oldUndelegateEvents;
-    this.modelEvents = this.listener._modelCallbacks;
+    this.customBindings = this.listener._customBindings;
     this.undelegateEvents();
   }
 
   _.extend(EventUndelegator.prototype, {
     undelegateEvents: function() {
       var listener = this.listener;
-      _.each(this.modelEvents, function(tuple) {
+      _.each(this.customBindings, function(tuple) {
         new EventUnbinder({listener: listener, tuple: tuple});
       });
       this.oldUndelegateEvents.call(listener);
@@ -122,7 +122,7 @@
     included: function(source) {
       _.extend(source.prototype, {
         initialize: _.wrap(source.prototype.initialize, function(oldInitialize, attrsOrModels, options) {
-          this._modelCallbacks = [];
+          this._customBindings = [];
           oldInitialize.call(this, attrsOrModels, options);
         }),
 

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -58,6 +58,7 @@
     this.subject = tuple[0];
     this.eventNames = tuple[1];
     this.context = tuple[2];
+    this.isJquery = !!_(this.subject).result('jquery');
     this.parse();
   }
   _.extend(EventHandler.prototype, {
@@ -72,12 +73,9 @@
         });
       });
     },
-    isJquery: function() {
-      return !!_(this.subject).result('jquery');
-    },
     handle: function(e, fn) {
       var handler = this.methodName;
-      if (this.isJquery()) {
+      if (this.isJquery) {
         if (this.context) {
           this.subject[handler](e, this.context, fn);
         } else {

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -9,15 +9,15 @@
       _.each(event.split(' '), function(e) {
         _.chain([callback]).flatten().each(function(c) {
           var fn = _.isFunction(c) ? c : self[c];
-            if (isJquery) {
-              if (context) {
-                subject.on(e, context, fn);
-              } else {
-                subject.on(e, fn);
-              }
+          if (isJquery) {
+            if (context) {
+              subject.on(e, context, fn);
             } else {
-              subject.on(e, fn, context);
+              subject.on(e, fn);
             }
+          } else {
+            subject.on(e, fn, context);
+          }
         });
       });
     });

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -1,6 +1,54 @@
 (function() {
   'use strict';
   var exports = this, _ = exports._, Backbone = exports.Backbone;
+
+  function noop() {}
+
+  var EventDelegator = function(params) {
+    this.listener = params.listener;
+    this.events = params.events;
+    this.delegateViewEvents = params.delegateViewEvents;
+    this.oldUndelegateEvents = this.listener.undelegateEvents;
+    this.delegateEvents();
+  };
+
+  _.extend(EventDelegator.prototype, {
+    delegateEvents: function() {
+      this.undelegateEvents();
+      this.temporarilyDisableUndelegation();
+      this._delegateEvents();
+      this.restoreUndelegation();
+    },
+    undelegateEvents: function() {
+      this.listener.undelegateEvents();
+    },
+    temporarilyDisableUndelegation: function() {
+      this.listener.undelegateEvents = noop;
+    },
+    restoreUndelegation: function() {
+      this.listener.undelegateEvents = this.oldUndelegateEvents;
+    },
+    _delegateEvents: function() {
+      var events = this.events;
+      var delegateViewEvents = this.delegateViewEvents;
+      var self = this.listener;
+      _.chain(events).toArray().compact().each(function(obj) {
+        var arg = _(obj);
+        if (arg.isArray()) {
+          bindModelEvents.call(self, obj);
+        } else {
+          arg.each(function(callbacks, event) {
+            _.chain([callbacks]).flatten().each(function(callback) {
+              delegateViewEvents.call(self, _.tap({}, function(obj) {
+                obj[event] = callback;
+              }));
+            });
+          });
+        }
+      });
+    }
+  });
+
   function bindModelEvents(tuple) {
     var self = this, subject = tuple[0], eventNames = tuple[1], isJquery = !!_(subject).result('jquery'),
         modelEvents = self._modelCallbacks, context = tuple[2];
@@ -46,14 +94,6 @@
     });
   }
 
-  function wrapUndelegateEvents(callback) {
-    var oldUndelegateEvents = this.undelegateEvents;
-    this.undelegateEvents();
-    this.undelegateEvents = function() {};
-    callback.call(this);
-    this.undelegateEvents = oldUndelegateEvents;
-  }
-
   var delegateEvents = {
     included: function(source) {
       _.extend(source.prototype, {
@@ -64,27 +104,15 @@
 
         delegateEvents: _.wrap(source.prototype.delegateEvents, function(oldDelegateEvents) {
           var self = this, args = _.rest(arguments);
-
           if (!args.length) {
             return oldDelegateEvents.call(this);
           }
-
-          wrapUndelegateEvents.call(this, function() {
-            _.chain(args).toArray().compact().each(function(obj) {
-              var arg = _(obj);
-              if (arg.isArray()) {
-                bindModelEvents.call(self, obj);
-              } else {
-                arg.each(function(callbacks, event) {
-                  _.chain([callbacks]).flatten().each(function(callback) {
-                    oldDelegateEvents.call(self, _.tap({}, function(obj) {
-                      obj[event] = callback;
-                    }));
-                  });
-                });
-              }
-            });
+          new EventDelegator({
+            delegateViewEvents: oldDelegateEvents,
+            listener: self,
+            events: args
           });
+
         }),
 
         undelegateEvents: _.wrap(source.prototype.undelegateEvents, function(oldUndelegateEvents) {

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -28,18 +28,24 @@
     restoreUndelegation: function() {
       this.listener.undelegateEvents = this.oldUndelegateEvents;
     },
+    customBindEvents: function(tuple) {
+      var modelEvents = this.listener._modelCallbacks;
+      modelEvents.push(tuple);
+      new EventBinder({listener: this.listener, tuple: tuple});
+    },
     _delegateEvents: function() {
       var events = this.events;
       var delegateViewEvents = this.delegateViewEvents;
-      var self = this.listener;
+      var self = this,
+          listener = this.listener;
       _.chain(events).toArray().compact().each(function(obj) {
         var arg = _(obj);
         if (arg.isArray()) {
-          bindModelEvents.call(self, obj);
+          self.customBindEvents(obj);
         } else {
           arg.each(function(callbacks, event) {
             _.chain([callbacks]).flatten().each(function(callback) {
-              delegateViewEvents.call(self, _.tap({}, function(obj) {
+              delegateViewEvents.call(listener, _.tap({}, function(obj) {
                 obj[event] = callback;
               }));
             });
@@ -100,12 +106,6 @@
   _.extend(EventUnbinder.prototype, EventHandler.prototype, {
     methodName: 'off'
   });
-
-  function bindModelEvents(tuple) {
-    var modelEvents = this._modelCallbacks;
-    modelEvents.push(tuple);
-    new EventBinder({listener: this, tuple: tuple});
-  }
 
   function unbindModelEvents() {
     var self = this, modelEvents = self._modelCallbacks;

--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -107,12 +107,23 @@
     methodName: 'off'
   });
 
-  function unbindModelEvents() {
-    var self = this, modelEvents = self._modelCallbacks;
-    _.each(modelEvents, function(tuple) {
-      new EventUnbinder({listener: self, tuple: tuple});
-    });
+  function EventUndelegator(params) {
+    this.listener = params.listener;
+    this.oldUndelegateEvents = params.oldUndelegateEvents;
+    this.modelEvents = this.listener._modelCallbacks;
+    this.undelegateEvents();
   }
+
+  _.extend(EventUndelegator.prototype, {
+    undelegateEvents: function() {
+      var listener = this.listener;
+      _.each(this.modelEvents, function(tuple) {
+        new EventUnbinder({listener: listener, tuple: tuple});
+      });
+      // TODO is this needed? deleting it leaves all specs passing
+      this.oldUndelegateEvents.call(this.listener);
+    }
+  });
 
   var delegateEvents = {
     included: function(source) {
@@ -136,8 +147,11 @@
         }),
 
         undelegateEvents: _.wrap(source.prototype.undelegateEvents, function(oldUndelegateEvents) {
-          unbindModelEvents.call(this);
-          return oldUndelegateEvents.call(this);
+          new EventUndelegator({
+            listener: this,
+            oldUndelegateEvents: oldUndelegateEvents
+          });
+          return this;
         }),
 
         remove: _.wrap(source.prototype.remove, function(oldRemove) {

--- a/spec/javascripts/delegate_events_spec.js
+++ b/spec/javascripts/delegate_events_spec.js
@@ -219,6 +219,24 @@ describe('delegateEvents', function() {
         expect($.fn.off.calls[0].args[1]).toEqual(selector);
       });
     });
+
+    describe('for typical Backbone view event bindings', function() {
+      beforeEach(function() {
+        jasmine.content().append('<div/>');
+      });
+      it('should unbind the events', function() {
+        var clickSpy = jasmine.createSpy('clickSpy');
+        subject = new Klass({el: jasmine.content()[0]});
+        jasmine.content().append('<div/>');
+        subject.delegateEvents({
+          'click div': clickSpy
+        });
+        subject.undelegateEvents();
+        subject.$("div").click();
+        expect(clickSpy).not.toHaveBeenCalled();
+      });
+    
+    });
   });
 
   describe("#remove", function() {


### PR DESCRIPTION
This PR refactors the event delegation module to use a more OO approach. It comes out with more LOC and is probably slower, but since I don't think this is (or should be) a very hot code path, I think (what I consider to be) the gains in readability offset these drawbacks.

But obviously if you prefer the existing style, that's fine. I was undertaking this refactor anyway for some other changes I'm making to this code, and thought I'd see if you were interested in the parts that leave functionality unchanged. Happy to discuss changes or squash into fewer commits, if you're interested.

In any case, you might be interested in cherry picking the first and last commits, which just change whitespace and add a spec that basically ensures Backbone.View#undelegateEvents is called.
