### PR TITLE
Moving association func on the outside of through

### DIFF
--- a/lib/assets/javascripts/backbone_extensions/associations.js
+++ b/lib/assets/javascripts/backbone_extensions/associations.js
@@ -14,11 +14,12 @@
       },
 
       buildAssociation: function(namespace, associationType, associationName, options) {
+        function association() {
+          var t = (_.isFunction(options.through) && options.through.call(this)) || _.str.camelize(options.through);
+          return this[t] && this[t]() && this[t]()[associationName] && this[t]()[associationName]();
+        }
+
         function through() {
-          function association() {
-            var t = (_.isFunction(options.through) && options.through.call(this)) || _.str.camelize(options.through);
-            return this[t] && this[t]() && this[t]()[associationName] && this[t]()[associationName]();
-          }
           return options.through && association.call(this);
         }
 


### PR DESCRIPTION
We've ran into an issue where Chrome 32 thinks that the nested **association** function in the **through** function is undefined. 

"TypeError: Cannot call method 'call' of undefined
    at through (http://localhost:3000/web/assets/backbone_extensions/associations.js?body=1:22:49)
    at associations.belongsTo (http://localhost:3000/web/assets/backbone_extensions/associations.js?body=1:48:82)
