### PR TITLE
Fix delegateEvents when called by Backbone.View.

### DIFF
--- a/lib/assets/javascripts/backbone_extensions/delegate_events.js
+++ b/lib/assets/javascripts/backbone_extensions/delegate_events.js
@@ -66,6 +66,9 @@
           var self = this, args = _.rest(arguments);
 
           if (!args.length) {
+            args = _([_.result(self, 'events')]).compact();
+          }
+          if(!args.length) {
             return oldDelegateEvents.call(this);
           }
 


### PR DESCRIPTION
This change allows events to be defined in an events hash on the prototype of the view,
as opposed to being passed as a hash directly in a call to #delegateEvents.

As per Backbone conventions the events property can be a hash or a function.
